### PR TITLE
Don't initialize `uinput` unless it's necessary

### DIFF
--- a/cecdaemon/remote.py
+++ b/cecdaemon/remote.py
@@ -41,7 +41,12 @@ class Remote:
         #pylint: disable=W0612
         for key, value in self.keymap.items():
             devicekeys.append(getattr(uinput, value))
-        self.device = uinput.Device(devicekeys)
+
+        # Avoid initializing uinput if the user doesn't need it (it can
+        # require special permissions the user may not even have).
+        if len(devicekeys) > 0:
+            self.device = uinput.Device(devicekeys)
+
         logging.info('Remote initialized')
 
     def eventrouter(self, event, key, state):


### PR DESCRIPTION
I'm only using `cecdaemon` to run commands, not to send keypresses via `uinput`. I'd like to avoid initializing `uinput` because it's a bit tricky to set up:

1. It requires the user I'm running `cecdaemon` under to have permissions it doesn't currently have.
2. It requires my system to have loaded the `uinput` kernel module, which doesn't actually happen on my device. See https://github.com/pyinput/python-uinput/issues/9#issuecomment-3568271848 for more details.

While I could fix both of these issues, this is such a minor change to `cecdaemon`, I thought it would be an acceptable change.