### PR TITLE
Add missing `pyudev` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently it is able to translate remote buttons to computer input, run shell co
 
 - [python-cec](https://github.com/trainman419/python-cec/)
 - [python-uinput](https://github.com/tuomasjjrasanen/python-uinput)
+- [pyudev](https://github.com/pyudev/pyudev)
 
 ## Installation:
 Installation should be done as root to allow installing commands to `/usr/bin/`

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='cecdaemon',
           ],
       keywords='libcec cec daemon htpc',
       packages=['cecdaemon'],
-      install_requires=['cec', 'python-uinput'],
+      install_requires=['cec', 'python-uinput', 'pyudev'],
       data_files=[('/usr/share/cecdaemon', [
           'examples/cecdaemon.conf-example',
           'examples/cecdaemon.service-example',


### PR DESCRIPTION
This was added to `requirements.txt` in
<https://github.com/simons-public/cecdaemon/commit/6a5efeba398383ab40d7aef3a02ad646ad78c850>, but not to the setup.py. This fixes that!